### PR TITLE
Updated webpack to produce node-compatible UMD build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,8 @@ const config = {
         filename: '[name].js',
         libraryTarget: 'umd',
         library: 'vocabulary',
-        umdNamedDefine: true
+        umdNamedDefine: true,
+        globalObject: 'typeof self !== \'undefined\' ? self : this' 
     },
     // Add resolve for `tsx` and `ts` files, otherwise Webpack would
     // only look for common JavaScript file extension (.js)


### PR DESCRIPTION
Reference: https://github.com/webpack/webpack/issues/6522

This branch:
```
▶ node
Welcome to Node.js v12.12.0.
> const vocab = require('./dist-umd/vocabulary');
undefined
> vocab
{
  AnnotationMotivation: {
    BOOKMARKING: 'oa:bookmarking',
    CLASSIFYING: 'oa:classifying',
    COMMENTING: 'oa:commenting',
    DESCRIBING: 'oa:describing',
    EDITING: 'oa:editing',
    HIGHLIGHTING: 'oa:highlighting',
    IDENTIFYING: 'oa:identifying',
    LINKING: 'oa:linking',
    MODERATING: 'oa:moderating',
    PAINTING: 'sc:painting',
    QUESTIONING: 'oa:questioning',
    REPLYING: 'oa:replying',
    TAGGING: 'oa:tagging',
    TRANSCRIBING: 'oad:transcribing'
....
```


Master branch:
```
▶ node
Welcome to Node.js v12.12.0.
Type ".help" for more information.
> const vocab = require('./dist-umd/vocabulary');
Thrown:
ReferenceError: window is not defined
    at Object.<anonymous> (/Users/stephen/github.com/iiif-commons/vocabulary/dist-umd/vocabulary.js:1:215)
    at Module._compile (internal/modules/cjs/loader.js:956:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:973:10)
    at Module.load (internal/modules/cjs/loader.js:812:32)
    at Function.Module._load (internal/modules/cjs/loader.js:724:14)
    at Module.require (internal/modules/cjs/loader.js:849:19)
    at require (internal/modules/cjs/helpers.js:74:18)
```